### PR TITLE
Set up GitHub Pages deployment

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,34 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/configure-pages@v3
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: .
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# test1
+# Simple Demo Site
+
+This repository contains a small two-page demo website inspired by [MillionPesos.com](https://millionpesos.com/). The site includes:
+
+- `index.html` – a home page that links to the About page
+- `about.html` – a short description of the project
+- `styles.css` – basic styling used by both pages
+
+## Publishing with GitHub Pages
+
+To publish this site on GitHub Pages:
+
+1. Create a new repository on GitHub and push this code to the `main` branch.
+2. In your repository settings, enable **GitHub Pages** and choose `GitHub Actions` as the source.
+3. The included workflow in `.github/workflows/github-pages.yml` will automatically deploy the site on every push to `main`.
+4. After the workflow completes, your site will be available at `https://<your-username>.github.io/<repository>`.
+
+Once configured, any changes pushed to `main` will update the published site automatically.

--- a/README.md
+++ b/README.md
@@ -16,3 +16,17 @@ To publish this site on GitHub Pages:
 4. After the workflow completes, your site will be available at `https://<your-username>.github.io/<repository>`.
 
 Once configured, any changes pushed to `main` will update the published site automatically.
+
+## Pushing to GitHub
+
+If this is a brand new repository, commit the files and push them to GitHub:
+
+```bash
+git init
+git add .
+git commit -m "Initial site"
+
+git remote add origin <your-repo-url>
+git branch -M main
+git push -u origin main
+```

--- a/about.html
+++ b/about.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>About - Million Pesos</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header>
+    <h1>About Million Pesos</h1>
+    <nav>
+      <a href="index.html">Home</a> |
+      <a href="about.html">About</a>
+    </nav>
+  </header>
+  <main>
+    <p>This page demonstrates a second page for our example website.</p>
+    <p>We are not affiliated with MillionPesos.com. This is just a simple demo.</p>
+  </main>
+  <footer>
+    <p>&copy; 2025 Million Pesos</p>
+  </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Million Pesos - Home</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header>
+    <h1>Million Pesos</h1>
+    <nav>
+      <a href="index.html">Home</a> |
+      <a href="about.html">About</a>
+    </nav>
+  </header>
+  <main>
+    <h2>Welcome!</h2>
+    <p>This small demo site is inspired by <a href="https://millionpesos.com">MillionPesos.com</a>.</p>
+  </main>
+  <footer>
+    <p>&copy; 2025 Million Pesos</p>
+  </footer>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,30 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  background-color: #f5f5f5;
+  color: #333;
+}
+
+header {
+  background-color: #222;
+  color: #fff;
+  padding: 1em;
+  text-align: center;
+}
+
+nav a {
+  color: #fff;
+  margin: 0 0.5em;
+  text-decoration: none;
+}
+
+main {
+  padding: 2em;
+}
+
+footer {
+  background-color: #eee;
+  padding: 1em;
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that deploys the root of the repository to GitHub Pages
- document steps to publish the site on GitHub Pages

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68862136391c83299efa00029a1561f8